### PR TITLE
feat(oidc): mock OIDC /authorize endpoint with redirect

### DIFF
--- a/oidc/example.com/README.md
+++ b/oidc/example.com/README.md
@@ -20,6 +20,23 @@ It will then automatically target the same server for all other OIDC endpoints.
 The OIDC client will trust any JWT signed with the [known private key](./privateKey.pem) matching the public key returned by the mock.
 This can be used to generate JWT tokens with expected claims, and which will never expire, for instance using https://jwt.io/.
 
+### Authorization (/authorize)
+
+The Authorize endpoint is used to implement SSO from other WebUIs.
+We can for instance use it from a Swagger UI, to get a Bearer access token to test our APIs.
+
+In the example metadata, we answer an HTTP 302 Redirect to the provided redirect_uri, with a token_type=Bearer and an access_token value which is based on:
+
+* the client_id parameter, to select a pre-built token (alice, bob, admin)
+* or default to using the value of client_id as the access token itself.
+
+Tokens need to be signed using the [private key](./privateKey.jwk), and can be generated using https://jwt.io/, with:
+
+* "iss" claim set to "microcks", i.e. matching the issue field returned by the discovery endpoint
+* "aud" claim set to the client_id of the service the token will be used to authenticate with
+* "exp" claim set far in the future, to avoid token expiration issues
+* Any other claim that the service expects, such as "sub", "scopes", etc.
+
 ### Token introspection (/tokeninfo)
 
 If the token is opaque, the OIDC client needs to validate it via the introspection endpoint.

--- a/oidc/example.com/oidc-1.0-openapi-metadata.yaml
+++ b/oidc/example.com/oidc-1.0-openapi-metadata.yaml
@@ -20,6 +20,55 @@ paths:
                       "n":"iJw33l1eVAsGoRlSyo-FCimeOc-AaZbzQ2iESA3Nkuo3TFb1zIkmt0kzlnWVGt48dkaIl13Vdefh9hqw_r9yNF8xZqX1fp0PnCWc5M_TX_ht5fm9y0TpbiVmsjeRMWZn4jr3DsFouxQ9aBXUJiu26V0vd2vrECeeAreFT4mtoHY13D2WVeJvboc5mEJcp50JNhxRCJ5UkY8jR_wfUk2Tzz4-fAj5xQaBccXnqJMu_1C6MjoCEiB7G1d13bVPReIeAGRKVJIF6ogoCN8JbrOhc_48lT4uyjbgnd24beatuKWodmWYhactFobRGYo5551cgMe8BoxpVQ4to30cGA0qjQ",
                       "e":"AQAB"
                     }]}
+  /authorize:
+    get:
+      x-microcks-operation:
+        dispatcher: FALLBACK
+        dispatcherRules: |-
+          {
+            "dispatcher": "URI_PARAMS",
+            "dispatcherRules": "client_id",
+            "fallback": "case_default"
+          }
+      parameters:
+        # Demo of using the client_id field from a Swagger UI to select the user, or to pass the token
+        - name: client_id
+          in: query
+          required: true
+          schema:
+            type: string
+          examples:
+            case_alice:
+              value: alice
+            case_bob:
+              value: bob
+            case_admin:
+              value: admin
+      responses:
+        "302":
+          headers:
+            Location:
+              examples:
+                case_alice:
+                  value: "{{ request.params[redirect_uri] }}?state={{ request.params[state] }}&token_type=Bearer&access_token=eyJraWQiOiIxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJhbGljZSIsInVzZXJuYW1lIjoiamRvZSIsImF1ZCI6Im15YXBwIiwiZ3JvdXBzIjpbInVzZXIiXSwiaXNzIjoibWljcm9ja3MiLCJleHAiOjIwNDc1NjgwMDUsImlhdCI6MTczMjAzMTYwNSwianRpIjoiNTFmOTMzYjktZjUwOC00YzQ3LTkwZGEtNmY5ODU1YTBkNDMzIn0.PVAUW1U2RadToh-QWPbcCuhJhSLhu_B5ID72-DgGZXMWd_Z_pWpQ7uvl1iLXtgv5-Nz3yakw_iv-uC2wj6Ls821lwTA0ncbVh3ix5fV0vLmx9EQWiSPbTv3qBG2VJsSbS_6uKolcHnnQrOEsjSDBACKmzs3bsgTqmW7eDdibHYEu-IYzxJQSOelA0K2yzmzxODMlTSfIU0K1W-D9_SkVlVxE5tHf2IjT7fErblDgIcte5eTI1VsOxWYx4epfNp_iznpyKvtrSvBD_YLRFHjpXPuFF_p33vs-zd3xJimE-4_0U2rMLgtWKEiAHcYi98KxWlM8PHDhEbnwOYvmXr__vw"
+                case_bob:
+                  value: "{{ request.params[redirect_uri] }}?state={{ request.params[state] }}&token_type=Bearer&access_token=eyJraWQiOiIxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJib2IiLCJ1c2VybmFtZSI6Impkb2UiLCJhdWQiOiJteWFwcCIsImdyb3VwcyI6WyJhcHBAcGVybWlzc2lvbiJdLCJpc3MiOiJtaWNyb2NrcyIsImV4cCI6MjA0NzU2ODAwNSwiaWF0IjoxNzMyMDMxNjA1LCJqdGkiOiI1MWY5MzNiOS1mNTA4LTRjNDctOTBkYS02Zjk4NTVhMGQ0MzMifQ.ajEnt_UTNkz6OpCITnlEd9ij7aivGSwtim47qOUzNxSjkFMcP9U-5sdOTnmJZlwQZSM48iDBay4VNjJobOgrOFYbfbAS-hkGxzTFzSXzCB817X2VsF71nZrwhR-MmdyB4ZEdvWqGZL6hD-gUMh_Ru9aWezV2xSNq_cqsmFCbC-fZndFFpYfVw-EB7FrvulWf9ITzl2PGp4dJGGkYh137eySmLEbnDmJjlCaxWim6WmmQf2Q2m-w366_ZCMEljR_EgAhm1sKnhsZAbl5ZrGEEaxzILA91DV7w6DHJNgDnSNYx3OP-KZH-Z-Xe2pHYFL5FAFAkN3oGZKAH5XIYdlXGbA"
+                case_admin:
+                  value: "{{ request.params[redirect_uri] }}?state={{ request.params[state] }}&token_type=Bearer&access_token=eyJraWQiOiIxIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJhZG1pbiIsImF1ZCI6Im15YXBwIiwiZ3JvdXBzIjpbInVzZXIiLCJhZG1pbiJdLCJpc3MiOiJtaWNyb2NrcyIsImV4cCI6MjA0NzU2ODAwNSwiaWF0IjoxNzMyMDMxNjA1LCJqdGkiOiI2YjkzMGEwMi01ZDM3LTRkYzYtOTNlZC1jMzM0NGYyZjI0MGEifQ.YVWe2ANIXMp5Nt66BG3d4Zg8Wdjxo4Zhb_lgaaNHDiJyUbF5UUBN47tuOoPklK_hATZ_RL21Vq_fBUKWvjwV3z4JoZN8FMHQjaQ8iie9rF1Z-5Fn8JQzPEFaVRPkZOhaR3B1MH8Tl_v3oY4GGhzRAPgeDRPKzfTDmm7ztPoTCflSveDMAOy7OqZOV89S8GP394VqjymQ_Mi3lA_mgfY5BfbIBTfMhzlpR1_FlbCkynXW_imhZeR3H0gxBLQzMRDzYgQKEzKY-029j2axH_JeIzoMC77XrQZZrcoRyIyHZRfy028CN4KXaumpH5FEEJOSNrWwzwP3zM1IZeHdapiFxg"
+                case_default:
+                  # Use the client_id as the access_token
+                  value: "{{ request.params[redirect_uri] }}?state={{ request.params[state] }}&token_type=Bearer&access_token={{ request.params[client_id] }}"
+          content:
+            application/text:
+              examples:
+                case_alice:
+                  value: "OK"
+                case_bob:
+                  value: "OK"
+                case_admin:
+                  value: "OK"
+                case_default:
+                  value: "OK"
   /token:
     post:
       responses:

--- a/oidc/example.com/oidc-1.0-openapi.yaml
+++ b/oidc/example.com/oidc-1.0-openapi.yaml
@@ -60,6 +60,99 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/JWKSetResponse'
+  /authorize:
+    get:
+      tags:
+        - OpenID Connect
+      summary: "Authorize users"
+      description: "An Authentication Request is an OAuth 2.0 Authorization Request that requests that the End-User be authenticated by the Authorization Server."
+      parameters:
+        - name: scope
+          in: query
+          description: "OpenID Connect requests MUST contain the openid scope value. If the openid scope value is not present, the behavior is entirely unspecified. Other scope values MAY be present. Scope values used that are not understood by an implementation SHOULD be ignored"
+          required: true
+          schema:
+            type: string
+        - name: response_type
+          in: query
+          description: "OAuth 2.0 Response Type value that determines the authorization processing flow to be used, including what parameters are returned from the endpoints used. When using the Authorization Code Flow, this value is code."
+          required: true
+          schema:
+            type: string
+        - name: client_id
+          in: query
+          description: "OAuth 2.0 Client Identifier valid at the Authorization Server."
+          required: true
+          schema:
+            type: string
+        - name: redirect_uri
+          in: query
+          description: "Redirection URI to which the response will be sent. This URI MUST exactly match one of the Redirection URI values for the Client pre-registered at the OpenID Provider. When using this flow, the Redirection URI SHOULD use the https scheme; however, it MAY use the http scheme, provided that the Client Type is confidential, as defined in Section 2.1 of OAuth 2.0, and provided the OP allows the use of http Redirection URIs in this case. Also, if the Client is a native application, it MAY use the http scheme with localhost or the IP loopback literals 127.0.0.1 or [::1] as the hostname. The Redirection URI MAY use an alternate scheme, such as one that is intended to identify a callback into a native application."
+          required: true
+          schema:
+            type: string
+        - name: state
+          in: query
+          description: "Opaque value used to maintain state between the request and the callback. Typically, Cross-Site Request Forgery (CSRF, XSRF) mitigation is done by cryptographically binding the value of this parameter with a browser cookie."
+          required: false
+          schema:
+            type: string
+        - name: response_mode
+          in: query
+          description: "Informs the Authorization Server of the mechanism to be used for returning parameters from the Authorization Endpoint. This use of this parameter is NOT RECOMMENDED when the Response Mode that would be requested is the default mode specified for the Response Type."
+          required: false
+          schema:
+            type: string
+      responses:
+        "302":
+          description: Redirect
+          content: { }
+    post:
+      tags:
+        - OpenID Connect
+      summary: "Authorize users"
+      description: "An Authentication Request is an OAuth 2.0 Authorization Request that requests that the End-User be authenticated by the Authorization Server."
+      parameters:
+        - name: scope
+          in: query
+          description: "OpenID Connect requests MUST contain the openid scope value. If the openid scope value is not present, the behavior is entirely unspecified. Other scope values MAY be present. Scope values used that are not understood by an implementation SHOULD be ignored"
+          required: true
+          schema:
+            type: string
+        - name: response_type
+          in: query
+          description: "OAuth 2.0 Response Type value that determines the authorization processing flow to be used, including what parameters are returned from the endpoints used. When using the Authorization Code Flow, this value is code."
+          required: true
+          schema:
+            type: string
+        - name: client_id
+          in: query
+          description: "OAuth 2.0 Client Identifier valid at the Authorization Server."
+          required: true
+          schema:
+            type: string
+        - name: redirect_uri
+          in: query
+          description: "Redirection URI to which the response will be sent. This URI MUST exactly match one of the Redirection URI values for the Client pre-registered at the OpenID Provider. When using this flow, the Redirection URI SHOULD use the https scheme; however, it MAY use the http scheme, provided that the Client Type is confidential, as defined in Section 2.1 of OAuth 2.0, and provided the OP allows the use of http Redirection URIs in this case. Also, if the Client is a native application, it MAY use the http scheme with localhost or the IP loopback literals 127.0.0.1 or [::1] as the hostname. The Redirection URI MAY use an alternate scheme, such as one that is intended to identify a callback into a native application."
+          required: true
+          schema:
+            type: string
+        - name: state
+          in: query
+          description: "Opaque value used to maintain state between the request and the callback. Typically, Cross-Site Request Forgery (CSRF, XSRF) mitigation is done by cryptographically binding the value of this parameter with a browser cookie."
+          required: false
+          schema:
+            type: string
+        - name: response_mode
+          in: query
+          description: "Informs the Authorization Server of the mechanism to be used for returning parameters from the Authorization Endpoint. This use of this parameter is NOT RECOMMENDED when the Response Mode that would be requested is the default mode specified for the Response Type."
+          required: false
+          schema:
+            type: string
+      responses:
+        "302":
+          description: Redirect
+          content: { }
   /userinfo:
     get:
       tags:


### PR DESCRIPTION
This is a follow-up of https://github.com/microcks/microcks-quickstarters/pull/1
It's adding OIDC /authorize endpoint, and using the technique mentioned in https://microcks.io/blog/mocking-oidc-redirect/ to  do a redirect to provided URI.
Here the client_id is used to either dispatch to a pre-defined token or fallback to a default case where token is mirrored. client_id happens to be one of the field available in the Swagger UI  "authorize" popup, so it was convenient to re-use this, rather than do a login form with an HTML mock.

/cc @lbroudoux 